### PR TITLE
Redirect reverse proxy

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,7 +1,7 @@
 $:.unshift( File.join(File::expand_path(File::dirname( __FILE__ )), 'lib' ).untaint )
 require 'tdiary/application'
 
-require_relative 'lib/rack/filter'
+require 'rack/redirect_reverse_proxy'
 use Rack::RedirectReverseProxy, ENV['PROXY_ADDR'] if ENV['PROXY_ADDR']
 
 use ::Rack::Reloader unless ENV['RACK_ENV'] == 'production'

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,8 @@
 $:.unshift( File.join(File::expand_path(File::dirname( __FILE__ )), 'lib' ).untaint )
 require 'tdiary/application'
 
+require_relative 'lib/rack/filter'
+use Rack::RedirectReverseProxy, ENV['PROXY_ADDR'] if ENV['PROXY_ADDR']
+
 use ::Rack::Reloader unless ENV['RACK_ENV'] == 'production'
 run TDiary::Application.new

--- a/lib/rack/redirect_reverse_proxy.rb
+++ b/lib/rack/redirect_reverse_proxy.rb
@@ -7,7 +7,7 @@ module Rack
 
 		def call(env)
 			#env.keys.sort.each{|key| p "#{key} = #{env[key]}"}
-			if env['REQUEST_PATH'] !~ %r|\A/update\.rb| && @address == env['HTTP_X_FORWARDED_FOR']
+			if env['REQUEST_PATH'] !~ %r|\A/update\.rb| && @address != env['HTTP_X_FORWARDED_FOR']
 				[
 					301,
 					{'location' => "http://sho.tdiary.net#{env['REQUEST_PATH']}"},

--- a/lib/rack/redirect_reverse_proxy.rb
+++ b/lib/rack/redirect_reverse_proxy.rb
@@ -10,7 +10,7 @@ module Rack
 			if env['REQUEST_PATH'] !~ %r|\A/update\.rb| && @address != env['HTTP_X_FORWARDED_FOR']
 				[
 					301,
-					{'location' => "http://sho.tdiary.net#{env['REQUEST_PATH']}"},
+					{'location' => "http://#{ENV['TDIARYNET_USER']}.tdiary.net#{env['REQUEST_PATH']}"},
 					[]
 				]
 			else

--- a/lib/rack/redirect_reverse_proxy.rb
+++ b/lib/rack/redirect_reverse_proxy.rb
@@ -7,7 +7,9 @@ module Rack
 
 		def call(env)
 			#env.keys.sort.each{|key| p "#{key} = #{env[key]}"}
-			if env['REQUEST_PATH'] !~ %r|\A/update\.rb| && @address != env['HTTP_X_FORWARDED_FOR']
+			if env['REQUEST_PATH'] !~ %r|\A/update\.rb| &&
+			   @address != env['HTTP_X_FORWARDED_FOR'] &&
+			   env['HTTP_REFERER'] !~ %r|\Ahttps?://tdiary-net-#{ENV['TDIARYNET_USER']}.herokuapp.com/update\.rb|
 				[
 					301,
 					{'location' => "http://#{ENV['TDIARYNET_USER']}.tdiary.net#{env['REQUEST_PATH']}"},

--- a/lib/rack/redirect_reverse_proxy.rb
+++ b/lib/rack/redirect_reverse_proxy.rb
@@ -1,0 +1,21 @@
+module Rack
+	class RedirectReverseProxy
+		def initialize(app, address)
+			@address = address
+			@app = app
+		end
+
+		def call(env)
+			#env.keys.sort.each{|key| p "#{key} = #{env[key]}"}
+			if env['REQUEST_PATH'] !~ %r|\A/update\.rb| && @address == env['HTTP_X_FORWARDED_FOR']
+				[
+					301,
+					{'location' => "http://sho.tdiary.net#{env['REQUEST_PATH']}"},
+					[]
+				]
+			else
+				@app.call(env)
+			end
+		end
+	end
+end


### PR DESCRIPTION
reverse proxyを迂回して直接日記を参照するリクエストは、reverse proxyへリダイレクトする。ただし、以下の場合はそのまま通す:

* 環境変数`PROXY_ADDR`がない (この機能をONにする場合はここにreverse proxyのIPアドレスを指定する)
* `/update.rb`配下の場合 (更新・設定は直接アクセスを行う)
* refererが`/update.rb`配下の場合 (更新・設定時にはアセットをリダイレクトしない)

なおこの機能はRack Middlewareを使って実装し、`config.ru`内で指定している。